### PR TITLE
fix firefox hoisting issue by defining mixinProp() function outside of for loop

### DIFF
--- a/dist/ng-active-resource.js
+++ b/dist/ng-active-resource.js
@@ -1046,6 +1046,23 @@ angular.module('ActiveResource').provider('ARHelpers', function () {
 angular.module('ActiveResource').provider('ARMixin', function () {
   this.$get = function () {
     return function (receiver, giver, excludeFunctions) {
+      function mixinProp() {
+        if (!receiver.hasOwnProperty(i)) {
+          (function () {
+            var local;
+            Object.defineProperty(receiver, i, {
+              enumerable: true,
+              get: function () {
+                return local;
+              },
+              set: function (val) {
+                local = val;
+              }
+            });
+          }());
+          receiver[i] = giver[i];
+        }
+      }
       if (giver.constructor.name == 'Function') {
         giver = new giver();
       }
@@ -1056,23 +1073,6 @@ angular.module('ActiveResource').provider('ARMixin', function () {
           }
         } else {
           mixinProp();
-        }
-        function mixinProp() {
-          if (!receiver.hasOwnProperty(i)) {
-            (function () {
-              var local;
-              Object.defineProperty(receiver, i, {
-                enumerable: true,
-                get: function () {
-                  return local;
-                },
-                set: function (val) {
-                  local = val;
-                }
-              });
-            }());
-            receiver[i] = giver[i];
-          }
         }
       }
       return receiver;


### PR DESCRIPTION
Please note that changes have only been made to the dist/ng-active-resource.js

In reference to the following issue,
https://github.com/FacultyCreative/ngActiveResource/issues/43

"The way the function mixinProp is currently being defined in the provider ARMixin doesn't work with firefox.

Firefox isn't hoisting mixinProp() as its being defined within a for loop and it is causing the following error:

Error: mixinProp is not defined

Please see gist and plunkr(open in firefox vs. open in chrome) to see the differences in hoisting

https://gist.github.com/jamesjtong/10272048
http://plnkr.co/edit/qrEuUUzDcwWjQFYILsaC?p=preview"
