### PR TITLE
fix firefox hoisting issue by defining mixinProp() function outside of for loop(block)

### DIFF
--- a/lib/angular-resource/base/base.js
+++ b/lib/angular-resource/base/base.js
@@ -259,6 +259,19 @@ angular
   .provider('ARMixin', function() {
     this.$get = function() {
       return function(receiver, giver, excludeFunctions) {
+        function mixinProp() {
+          if (!receiver.hasOwnProperty(i)) {
+            (function() {
+              var local;
+              Object.defineProperty(receiver, i, {
+                enumerable: true,
+                get: function()    { return local; },
+                set: function(val) { local = val; }
+              });
+            })();
+            receiver[i] = giver[i];
+          }
+        }
         if (giver.constructor.name == 'Function') {
           giver = new giver();
         }
@@ -269,19 +282,6 @@ angular
             }
           } else {
             mixinProp();
-          }
-          function mixinProp() {
-            if (!receiver.hasOwnProperty(i)) {
-              (function() {
-                var local;
-                Object.defineProperty(receiver, i, {
-                  enumerable: true,
-                  get: function()    { return local; },
-                  set: function(val) { local = val; }
-                });
-              })();
-              receiver[i] = giver[i];
-            }
           }
         }
         return receiver;


### PR DESCRIPTION
In reference to the following issue,
#43

"The way the function mixinProp is currently being defined in the provider ARMixin doesn't work with firefox.

Firefox isn't hoisting mixinProp() as its being defined within a for loop and it is causing the following error:

Error: mixinProp is not defined

Please see gist and plunkr(open in firefox vs. open in chrome) to see the differences in hoisting

https://gist.github.com/jamesjtong/10272048
http://plnkr.co/edit/qrEuUUzDcwWjQFYILsaC?p=preview"
